### PR TITLE
Pluggin patch and an addition to the api

### DIFF
--- a/IBDCluster/analysis/main.py
+++ b/IBDCluster/analysis/main.py
@@ -30,7 +30,9 @@ def analyze(data_container: DataHolder, output: str) -> None:
 
         analysis_plugins = [plugins.factory_create(item) for item in config["modules"]]
 
-        logger.info(f"Using plugins: {', '.join(analysis_plugins)}")
+        logger.info(
+            f"Using plugins: {', '.join([obj.name for obj in analysis_plugins])}"
+        )
 
         # iterating over every plugin and then running the analyze and write method
         for analysis_obj in analysis_plugins:

--- a/IBDCluster/models/data_container.py
+++ b/IBDCluster/models/data_container.py
@@ -12,3 +12,4 @@ class DataHolder:
     phenotype_cols: List[str]
     ibd_program: str
     phenotype_percentages: Dict[str, float] = field(default_factory=dict)
+    network_pvalues: Dict[int, Dict[str, float]] = field(default_factory=dict)

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ help:
 
 clean:
 	@echo "Cleaning up output files from test environment"
-	@rm -r tests/TEST_GENE/ tests/*.log 
+	@rm -r tests/TEST_GENE/ tests/*.log tests/percent_carriers_in_population.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cluster"
-version = "1.0.0"
+version = "1.0.1"
 description = "A tool to help analyze ibd sharing across a locus of interest for all phenotypes."
 authors = ["jtb324 <james.baker@vanderbilt.edu>"]
 

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,0 +1,14 @@
+{
+    "plugins":["plugins.phecode_percentages", "plugins.network_writer", "plugins.allpair_writer"],
+    "modules": [
+        {
+            "name": "phecode_percentages"
+        },
+        {
+            "name": "network_writer"
+        },
+        {
+            "name": "allpair_writer"
+        }
+    ]
+}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,6 +27,8 @@ def test_sucessful_run():
             "5",
             "-l",
             "verbose",
+            "-j",
+            "./config.json",
         ],
     )
 
@@ -40,9 +42,7 @@ def test_percent_carriers_output():
 
     errors = []
 
-    percentage_df = pd.read_csv(
-        "./TEST_GENE/percent_carriers_in_population.txt", sep="\t"
-    )
+    percentage_df = pd.read_csv("./percent_carriers_in_population.txt", sep="\t")
 
     # first we are going to make sure that the percentage_df has the
     # right column


### PR DESCRIPTION
Fixed some bugs with how the program was identifying the config.json file. Now it is an optional argument. Also fixed the integration tests so that they could file the config file and the percent_carriers_in_population.txt file since it is not output to the same directories as the networks and allpairs files anymore. Also made it so that the network_writer plugin adds the phenotype pvalues for each network to an attribute of the dataHolder object called the pvalue_dictionary. This change allows for plugins to use those pvalues without recalculating them. Also bump up version to 1.0.1