### PR TITLE
Refactor multi target

### DIFF
--- a/IBDCluster/IBDCluster.py
+++ b/IBDCluster/IBDCluster.py
@@ -12,6 +12,7 @@ import analysis
 import callbacks
 import cluster
 import log
+from datetime import datetime
 from models import DataHolder
 
 
@@ -90,6 +91,9 @@ def main(
 ) -> None:
     """Main function for the program that has all the parameters that the user can use with type"""
 
+    # getting the programs start time
+    start_time = datetime.now()
+
     # create the directory that the IBDCluster.log will be in
     pathlib.Path(output).mkdir(parents=True, exist_ok=True)
 
@@ -153,6 +157,7 @@ def main(
     analysis.analyze(data_container, output)
 
     logger.info("analysis_finished")
+    logger.info(f"Program Duration: {datetime.now() - start_time}")
 
 
 if __name__ == "__main__":

--- a/IBDCluster/IBDCluster.py
+++ b/IBDCluster/IBDCluster.py
@@ -13,7 +13,7 @@ import callbacks
 import cluster
 import log
 from datetime import datetime
-from models import DataHolder
+from models import DataHolder, Network
 
 
 app = typer.Typer(
@@ -142,19 +142,29 @@ def main(
 
     carriers_dict = cluster.generate_carrier_list(carriers_df)
 
+    genes_generator = cluster.load_gene_info(gene_info_file)
+
     # We can then determine the different clusters for each gene
-    networks: Dict[Tuple[str, int], List] = cluster.find_clusters(
-        ibd_program, gene_info_file, cm_threshold, carriers_dict
-    )
+    for gene in genes_generator:
 
-    # adding the networks, the carriers_df, the carriers_dict, and the
-    # phenotype columns to a object that will be used in the analysis
-    data_container = DataHolder(
-        networks, carriers_dict, carriers_df, carriers_df.columns[1:], ibd_program
-    )
+        networks_list: List[Network] = cluster.find_clusters(
+            ibd_program, gene, cm_threshold, carriers_dict
+        )
 
-    # This is the main function that will run the analysis of the networks
-    analysis.analyze(data_container, output)
+        # adding the networks, the carriers_df, the carriers_dict, and the
+        # phenotype columns to a object that will be used in the analysis
+        data_container = DataHolder(
+            gene.name,
+            gene.chr,
+            networks_list,
+            carriers_dict,
+            carriers_df,
+            carriers_df.columns[1:],
+            ibd_program,
+        )
+
+        # This is the main function that will run the analysis of the networks
+        analysis.analyze(data_container, output)
 
     logger.info("analysis_finished")
     logger.info(f"Program Duration: {datetime.now() - start_time}")

--- a/IBDCluster/IBDCluster.py
+++ b/IBDCluster/IBDCluster.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python
-
-import callbacks
-import typer
-import cluster
-import log
+"""
+This module is the main script for the IBDCluster program. It contains the main cli and records inputs and creates the typer app.
+"""
 import os
-import analysis
+from typing import Dict, Tuple, List
+import pathlib
 from dotenv import load_dotenv
 import pandas as pd
-from typing import Dict, Tuple, List
+import typer
+import analysis
+import callbacks
+import cluster
+import log
 from models import DataHolder
-import pathlib
 
 
 app = typer.Typer(

--- a/IBDCluster/analysis/main.py
+++ b/IBDCluster/analysis/main.py
@@ -20,7 +20,7 @@ def analyze(data_container: DataHolder, output: str) -> None:
 
     output : str
     """
-    print(os.environ.get("json_path"))
+
     # This section will load in the analysis plugins
     with open(os.environ.get("json_path")) as json_config:
 
@@ -37,9 +37,12 @@ def analyze(data_container: DataHolder, output: str) -> None:
         # iterating over every plugin and then running the analyze and write method
         for analysis_obj in analysis_plugins:
 
+            logger.debug(analysis_obj.name)
+
             return_data: Dict[str, Any] = analysis_obj.analyze(
                 data=data_container, output=output
             )
+
             # writing the output to a file
             analysis_obj.write(
                 input_data=return_data,

--- a/IBDCluster/cluster/__init__.py
+++ b/IBDCluster/cluster/__init__.py
@@ -1,1 +1,1 @@
-from .main import find_clusters, generate_carrier_list
+from .main import find_clusters, generate_carrier_list, load_gene_info

--- a/IBDCluster/models/data_container.py
+++ b/IBDCluster/models/data_container.py
@@ -1,12 +1,14 @@
 from dataclasses import dataclass, field
-from typing import Dict, Tuple, List
+from typing import Dict, List
 from models import Network
 import pandas as pd
 
 
 @dataclass
 class DataHolder:
-    networks_dict: Dict[Tuple[str, int], List[Network]]
+    gene_name: str
+    chromosome: int
+    networks_list: List[Network]
     affected_inds: Dict[float, List[str]]
     phenotype_table: pd.DataFrame
     phenotype_cols: List[str]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-# IBDCluster v0.9.1:
+# IBDCluster v1.0.1:
 
 ## Purpose of the project: 
 ___
@@ -87,6 +87,10 @@ IBDCluster.py --help
 ## Running the code:
 ___
 *
+
+## Reporting Issues:
+___
+All issues can be reported using the templates in the .github/ folder. There are options for bug_reports and for feature_request
 
 ## Technical Details of the project:
 ___

--- a/poetry.lock
+++ b/poetry.lock
@@ -466,6 +466,17 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
+name = "perflint"
+version = "0.7.1"
+description = "Pylint extension with performance anti-patterns"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pylint = ">=2.12.0,<3.0"
+
+[[package]]
 name = "pexpect"
 version = "4.8.0"
 description = "Pexpect allows easy control of interactive console applications."
@@ -874,7 +885,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11"
-content-hash = "888a5a0e98b51ab6e1876d63c557254313feeae000a001f5d8464f1133a231f3"
+content-hash = "428521087a2ab33c759c362dc86b840e38bdef46a9a42ae64795153f8efb5436"
 
 [metadata.files]
 appnope = [
@@ -1248,6 +1259,10 @@ parso = [
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+perflint = [
+    {file = "perflint-0.7.1-py2.py3-none-any.whl", hash = "sha256:471ea1ab67a336409a3c0ac51fd8d15e3a79961fab2b408ed3b8718c62d9efd6"},
+    {file = "perflint-0.7.1.tar.gz", hash = "sha256:68711e3ec5020876bb8fee2ae94b75a77cfbc64231bb0d0645d58ee78a1255c2"},
 ]
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pydantic = "^1.9.0"
 snakeviz = "^2.1.1"
 data-science-types = "^0.2.23"
 pre-commit = "^2.17.0"
+perflint = "^0.7.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
changed the program so that it creates the gene generator in the IBDCluster.py object and then iterates over that in the same file versus doing it in the cluster/main.py file. Due to this I changed the plugins returns so that they didn't iterate over each gene and instead just returned a dictionary instead of a nested dictionary. Also changed the return dictionary for the network_writer.py and the allpair_writer.py. This change makes sure that the program uses a constant memory versus accruing more memory for each gene.