### PR TITLE
Removed the need for the gene info file:

### DIFF
--- a/IBDCluster/callbacks/__init__.py
+++ b/IBDCluster/callbacks/__init__.py
@@ -1,6 +1,6 @@
 from .check_inputs import (
-    check_gene_file,
     check_json_path,
     check_env_path,
     display_version,
+    check_gene_pos_str,
 )

--- a/IBDCluster/callbacks/check_inputs.py
+++ b/IBDCluster/callbacks/check_inputs.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import typer
 import os
 import toml
+import re
 
 __version__ = "1.2.1"
 
@@ -25,40 +26,30 @@ class IncorrectGeneFileFormat(Exception):
         super().__init__(message)
 
 
-def check_gene_file(gene_filepath: str) -> str:
-    """Function that will check to make sure the gene info file exist or else it will raise an error.
+def check_gene_pos_str(gene_pos_str: str) -> str:
+    """Callback function that will make sure that the user inputs a gene_pos_str of for X:Start-End. If not then it raises a value error
 
     Parameters
-
-    gene_filepath : str
-        filepath to a text file that has information about the gene/genes of interests
+    ----------
+    gene_pos_str : str
+        string that has the region of interest defined by chromo:start_position-end_position. An example is 10:1234-1234.
 
     Returns
-
+    -------
     str
-        returns the filepath
+        returns the gene_pos_str
+
+    Raises
+    ------
+    ValueError
+        raises a value error if the user inputs a incorrectly formatted string
     """
-    file_path = Path(gene_filepath)
-
-    if not file_path.exists():
-        raise FileNotFoundError(f"The file at {file_path} was not found")
-    if gene_filepath[-4:] != ".txt":
-        raise IncorrectFileType(
-            gene_filepath[-4:],
-            "The filetype provided for the gene info file is incorrect. Please provided a tab delimited text file",
+    if len(re.split(":|-", gene_pos_str)) == 0:
+        raise ValueError(
+            f"Expected the gene position string to be formatted like chromosome:start_position-end_position. Instead it was formatted as {gene_pos_str}"
         )
-    # next section will check and make sure that the gene information is in the right format
-    with open(gene_filepath, "r", encoding="utf-8") as gene_file:
-
-        line = gene_file.readline().split("\t")
-
-        if line[0].isnumeric():
-            raise IncorrectGeneFileFormat(
-                line[0],
-                f"Expected the first value of the Gene Info file to be a gene name. Instead it was able to be converted to a number. Did you switch the chromosome number with the gene name? Value found in file {line[0]}",
-            )
-
-    return gene_filepath
+    else:
+        return gene_pos_str
 
 
 def check_json_path(json_path: str) -> str:


### PR DESCRIPTION
---
1. Removed the gene info file input:

Replaced this flag with 2 flags: gene_position and gene_name. These can be provided by the user. The motivation is that the program was not designed in a way to run multiple gene targets from the gene info file so this file was restricted to one line anyways and was unnecessarily. This input is recorded in the log file so the user can still tell what they ran. The --gene-position flag expects the user to provided a string of the format "chromosome:start_position-end-position". The --gene-name flag allows the user to give a name to the gene. This flag defaults to test if the user doesn't provided anything.

2. Updated the load_gene_info function in the cluster.main file:

This function now returns a list of Genes instead of a generator. The function uses a regular expression to pull out the chromosome number and start/end positions from the provide chromo_pos_str. Still retains the ability to create a sliding window every 1MB.

3. Add a callback to check the format of the --gene-position string:

Added a function called check_gene_pos_str in callbacks.check_inputs.py. This function makes sure that the string is formatted as "chromosome:start_position-end_position". This format is checked using the re.split to make sure that the resulting split list is of length 3. If there is a format issue than a ValueError is raised with a message

Things to do:
---
These changes broke the unit test for the sliding window function. So this needs to be fixed